### PR TITLE
Loading zope.security ZCML causes wrong permissions to appear

### DIFF
--- a/collective/geo/geographer/tests/test_permissions.py
+++ b/collective/geo/geographer/tests/test_permissions.py
@@ -1,0 +1,29 @@
+from collective.geo.geographer.testing import CGEO_GEOGRAPHER_INTEGRATION
+from operator import itemgetter
+from unittest2 import TestCase
+
+
+class TestViewPermissionRegression(TestCase):
+
+    layer = CGEO_GEOGRAPHER_INTEGRATION
+
+    def test_view_permission(self):
+        # The message-id of the translated title of the "View" permission
+        # is "view-permission".
+        # The literal "view-permission" should never be listed
+        # in manage_access, only "View" should.
+        # Loading the ZCML in a wrong way results in having both registered,
+        # which is wrong.
+
+        app = self.layer['portal']
+
+        # contains a list of tuples, e.g.
+        # ('Modify portal content', (), ('Editor'))
+        permission_tuples = app.ac_inherited_permissions(1)
+
+        permission_names = map(itemgetter(0), permission_tuples)
+
+        self.assertNotIn(
+            'view-permission', permission_names,
+            'The string "view-permission" should never be in manage_acces.'
+            ' Something went wrong while loading ZCML.')


### PR DESCRIPTION
**No fix included, only a failing test.**

---

**Symptom**
It seems that collective.geo.geographer somehow causes the zope.security permissions to be registered wrong: somehow the permission in manage_access is registered with the translation id (e.g. view-permission) instead of the translation default (View).

![manage_access](https://f.cloud.github.com/assets/7469/308055/50ecbc46-96db-11e2-9b18-b449638c15b4.png)

The permissions marked in the screenshot do not appear when installing only Plone, but they appear when installing collective.geo.geographer (Plone-4.3rc1).

**Cause**
The permissions are defined in [zope.security permissions.zcml](https://github.com/zopefoundation/zope.security/blob/3.8.3/src/zope/security/permissions.zcml#L19) as translatable (msgid is "view-permission", default is "View").

I think the zope.security permissions.zcml is not loaded by Plone by default, because the `View` permission is also defined in [AccessControl's permissions.zcml](https://github.com/zopefoundation/AccessControl/blob/3.0.6/src/AccessControl/permissions.zcml#L76), which is used by Plone.

**Problem**
So the `zope.security` permissions are something new, I think, which is not used by Plone at all and should therefore not be loaded.
collective.geo.grapher loads zope.security in [the configure.zcml](https://github.com/collective/collective.geo.geographer/blob/master/collective/geo/geographer/configure.zcml#L10), because it uses `zope.View` (not `zope2.View`) and `zope.ManageContent`).

**Fix?**

I think collective.geo.geographer should use load the `AccessControl` permissions and use `zope2.View` (AccessControl) instead of `zope.View` (zope.security).
But I'm not sure what to do with `zope.ManageContent`, with which `zope2.*` or Plone permission should it be replaced?

I'll happily change it as soon as I know which permission to use and update the pull request.
The pull request currently only contains a failing test illustrating the problem.
