### PR TITLE
IObjectGeoreferencedEvent doesn't acquire from IObjectModifiedEvent anymore

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,10 +7,11 @@ Changelog
 
 - Removed unittest2 using unittest instead.
   [giorgio]
-
 - using PLONE_APP_CONTENTTYPES_FIXTURE to make tests plone5 compatible
   [pbauer]
-
+- ``IObjectGeoreferencedEvent`` doesn't acquire from ``IObjectModifiedEvent``
+  anymore. See `issue 5 on collective.geo.geographer`_.
+  [keul]
 
 2.0 (2013-10-29)
 ----------------
@@ -90,3 +91,5 @@ Changelog
 * removed zgeo.geographer dependency
 * zgeo.plone.geographer code refactoring
 * moved from zgeo.plone.geographer
+
+.. _`issue 5 on collective.geo.geographer`: https://github.com/collective/collective.geo.geographer/issues/5

--- a/src/collective/geo/geographer/event.py
+++ b/src/collective/geo/geographer/event.py
@@ -1,11 +1,11 @@
 from zope.interface import implements
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+from zope.component.interfaces import IObjectEvent
 
 import logging
 logger = logging.getLogger('collective.geo.geographer')
 
 
-class IObjectGeoreferencedEvent(IObjectModifiedEvent):
+class IObjectGeoreferencedEvent(IObjectEvent):
     """An event signaling that an object has been georeferenced
     """
 


### PR DESCRIPTION
This close #5.

This needs evaluation: not acquiring from ``IObjectModifiedEvent`` means also that other triggers notified on modify are no more.
Can this lead to some kind of issues?